### PR TITLE
ホーム画面・クイズ画面をSPA化するために、Home.vueを編集しました。

### DIFF
--- a/resources/js/components/page/Home.vue
+++ b/resources/js/components/page/Home.vue
@@ -15,31 +15,31 @@
             <h2 class="home-quiz__setting-h2">
               <img class="home-quiz__setting-h2-logo" src="/images/directory-icon.png" />出題設定
             </h2>
-            <form action="/quiz" method="post">
+            <form>
               <label>
-                <input type="checkbox" name="categories[]" value="1" checked />ビジネスマナー
+                <input type="checkbox" v-model="categories" value="1" checked />ビジネスマナー
               </label>
               <label>
-                <input type="checkbox" name="categories[]" value="2" />一般常識
+                <input type="checkbox" v-model="categories" value="2" />一般常識
               </label>
               <label>
-                <input type="checkbox" name="categories[]" value="3" />就職・転職
+                <input type="checkbox" v-model="categories" value="3" />就職・転職
               </label>
               <label>
-                <input type="checkbox" name="categories[]" value="4" />法律
+                <input type="checkbox" v-model="categories" value="4" />法律
               </label>
               <label>
-                <input type="checkbox" name="categories[]" value="5" />IT
+                <input type="checkbox" v-model="categories" value="5" />IT
               </label>
               <label>
-                <input type="checkbox" name="categories[]" value="6" />雑学
+                <input type="checkbox" v-model="categories" value="6" />雑学
               </label>
               <div class>
                 全項目チェック
                 <button type="button" name="check_all" id="check-all" value="1">ON</button>
                 <button type="button" name="check_all_off" id="check-all-off" value="1">OFF</button>
               </div>
-              <button type="submit" class="btn btn-primary">出題開始</button>
+              <button type="submit" class="btn btn-primary" @click.stop.prevent="goQuiz()">出題開始</button>
               <input type="hidden" name="_token" value />
             </form>
           </section>
@@ -91,6 +91,16 @@ export default {
     TheFooter,
     TheSidebar,
     BarChart,
-  }
+  },
+    data() {
+        return {
+            categories: [1]
+        };
+    },
+    methods: {
+        goQuiz() {
+            this.$router.push("/quiz?categories=" + this.categories);
+        }
+    }
 };
 </script>


### PR DESCRIPTION
## やったこと

出題開始ボタンをクリックしたら画面のリロードなしに、クイズページへ移行するようにHome.vueを編集しました。

## やらないこと

無し

## できるようになること（ユーザ目線）

ホーム画面の出題開始ボタンをクリックしたら画面のリロードなしに、クイズページへ移行

## できなくなること（ユーザ目線）

無し

## 動作確認

ホーム画面の出題開始ボタンをクリックした後、クイズページに移行するかを確認しました。

■ホーム画面
<img width="915" alt="スクリーンショット 2020-10-27 11 03 37" src="https://user-images.githubusercontent.com/63224224/97248010-286ce500-1844-11eb-9c7b-3eaf1cc20cbb.png">

■ホーム画面から出題開始ボタンをクリック後
<img width="895" alt="スクリーンショット 2020-10-27 11 03 50" src="https://user-images.githubusercontent.com/63224224/97248017-2e62c600-1844-11eb-9b9c-b5fa8fade43c.png">


## その他

無し