### PR TITLE
クイズ画面のクイズ出題API連携を実装する。対応するURLと呼び出すコントローラーを設定するために、laravel_vue_quiz/routes/api.phpを編集しました。

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -22,9 +22,9 @@
     <select />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="ac1f6fcc-735f-4ba6-9b07-4b605d0df73f" name="Default Changelist" comment="シーダーで実行したDatabaseの値を呼び出すために、laravel_vue_quiz/app/Http/Controllers/Api/CategoryController.phpを編集しました。">
+    <list default="true" id="ac1f6fcc-735f-4ba6-9b07-4b605d0df73f" name="Default Changelist" comment="ホーム画面からAPIを呼び出すために、laravel_vue_quiz/resources/js/components/page/Home.vueを編集しました。">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/resources/js/components/page/Home.vue" beforeDir="false" afterPath="$PROJECT_DIR$/resources/js/components/page/Home.vue" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/routes/api.php" beforeDir="false" afterPath="$PROJECT_DIR$/routes/api.php" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -197,7 +197,7 @@
       <workItem from="1601259652604" duration="1820000" />
       <workItem from="1602551923918" duration="2429000" />
       <workItem from="1603169585878" duration="35550000" />
-      <workItem from="1603866491884" duration="25504000" />
+      <workItem from="1603866491884" duration="26281000" />
     </task>
     <task id="LOCAL-00001" summary="first commit　laravelのディレクトリを作成">
       <created>1600935074824</created>
@@ -472,7 +472,14 @@
       <option name="project" value="LOCAL" />
       <updated>1604300342829</updated>
     </task>
-    <option name="localTasksCounter" value="40" />
+    <task id="LOCAL-00040" summary="ホーム画面からAPIを呼び出すために、laravel_vue_quiz/resources/js/components/page/Home.vueを編集しました。">
+      <created>1604301737852</created>
+      <option name="number" value="00040" />
+      <option name="presentableId" value="LOCAL-00040" />
+      <option name="project" value="LOCAL" />
+      <updated>1604301737852</updated>
+    </task>
+    <option name="localTasksCounter" value="41" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -491,7 +498,6 @@
     <option name="oldMeFiltersMigrated" value="true" />
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="画像パスを修正するために、laravel_vue_quiz/resources/js/components/page/Home.vueを編集しました。" />
     <MESSAGE value="クイズ画面の画像パスを修正するために、laravel_vue_quiz/resources/views/quiz/index.blade.phpを編集しました。" />
     <MESSAGE value="クイズ画面の画像パスを修正するために、laravel_vue_quiz/resources/js/components/page/quiz.vueを編集しました。" />
     <MESSAGE value="vue-routerをインストールし、ルーティングの設定のためlaravel_vue_quiz/resources/js/router.jsを新規作成しました。" />
@@ -516,7 +522,8 @@
     <MESSAGE value="ホーム画面のクイズカテゴリーAPI連携を実装するため、Categoryモデル（laravel_vue_quiz/app/Category.php）を作成し、編集しました。" />
     <MESSAGE value="ホーム画面のクイズカテゴリーAPI連携を実装するため、Categoryシーダー(laravel_vue_quiz/database/seeds/CategoryTableSeeder.php)を作成し、編集しました。" />
     <MESSAGE value="シーダーで実行したDatabaseの値を呼び出すために、laravel_vue_quiz/app/Http/Controllers/Api/CategoryController.phpを編集しました。" />
-    <option name="LAST_COMMIT_MESSAGE" value="シーダーで実行したDatabaseの値を呼び出すために、laravel_vue_quiz/app/Http/Controllers/Api/CategoryController.phpを編集しました。" />
+    <MESSAGE value="ホーム画面からAPIを呼び出すために、laravel_vue_quiz/resources/js/components/page/Home.vueを編集しました。" />
+    <option name="LAST_COMMIT_MESSAGE" value="ホーム画面からAPIを呼び出すために、laravel_vue_quiz/resources/js/components/page/Home.vueを編集しました。" />
   </component>
   <component name="WindowStateProjectService">
     <state x="1064" y="380" key="#com.intellij.fileTypes.FileTypeChooser" timestamp="1603771211925">
@@ -547,10 +554,10 @@
       <screen x="0" y="23" width="1792" height="1097" />
     </state>
     <state x="747" y="209" key="SettingsEditor/0.23.1792.1097@0.23.1792.1097" timestamp="1604288623803" />
-    <state x="789" y="309" key="Vcs.Push.Dialog.v2" timestamp="1604300351165">
+    <state x="789" y="309" key="Vcs.Push.Dialog.v2" timestamp="1604301744653">
       <screen x="0" y="23" width="1792" height="1097" />
     </state>
-    <state x="789" y="309" key="Vcs.Push.Dialog.v2/0.23.1792.1097@0.23.1792.1097" timestamp="1604300351165" />
+    <state x="789" y="309" key="Vcs.Push.Dialog.v2/0.23.1792.1097@0.23.1792.1097" timestamp="1604301744653" />
     <state x="900" y="123" width="792" height="893" key="com.intellij.history.integration.ui.views.FileHistoryDialog" timestamp="1600932790272">
       <screen x="0" y="23" width="1792" height="1097" />
     </state>

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,4 +21,5 @@ Route::middleware('auth:api')->get('/user', function (Request $request) {
 Route::group(['middleware' => ['api']], function () {
     Route::get('information', 'App\Http\Controllers\Api\InformationController@index');
     Route::get('category', 'App\Http\Controllers\Api\CategoryController@index');
+    Route::get('quiz', 'App\Http\Controllers\Api\QuizController@index');
 });


### PR DESCRIPTION
## やったこと

クイズ画面のクイズ出題API連携を実装する。
対応するURLと呼び出すコントローラーを設定するために、laravel_vue_quiz/routes/api.phpを編集しました。

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

無し

## その他

無し
