### PR TITLE
Quiz画面のクイズ出題の2問目以降の問題を表示するため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -22,7 +22,7 @@
     <select />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="ac1f6fcc-735f-4ba6-9b07-4b605d0df73f" name="Default Changelist" comment="Quiz画面からAPIを呼び出すため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。">
+    <list default="true" id="ac1f6fcc-735f-4ba6-9b07-4b605d0df73f" name="Default Changelist" comment="API連携でデータを表示するため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/resources/js/components/page/quiz.vue" beforeDir="false" afterPath="$PROJECT_DIR$/resources/js/components/page/quiz.vue" afterDir="false" />
     </list>
@@ -197,14 +197,7 @@
       <workItem from="1601259652604" duration="1820000" />
       <workItem from="1602551923918" duration="2429000" />
       <workItem from="1603169585878" duration="35550000" />
-      <workItem from="1603866491884" duration="33512000" />
-    </task>
-    <task id="LOCAL-00001" summary="first commit　laravelのディレクトリを作成">
-      <created>1600935074824</created>
-      <option name="number" value="00001" />
-      <option name="presentableId" value="LOCAL-00001" />
-      <option name="project" value="LOCAL" />
-      <updated>1600935074824</updated>
+      <workItem from="1603866491884" duration="36056000" />
     </task>
     <task id="LOCAL-00002" summary="画像ファイルを、vue_hello/public/laravel_vue_quiz/public/imagesに移行しました。">
       <created>1603169976667</created>
@@ -542,7 +535,14 @@
       <option name="project" value="LOCAL" />
       <updated>1604906168115</updated>
     </task>
-    <option name="localTasksCounter" value="50" />
+    <task id="LOCAL-00050" summary="API連携でデータを表示するため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。">
+      <created>1604906727955</created>
+      <option name="number" value="00050" />
+      <option name="presentableId" value="LOCAL-00050" />
+      <option name="project" value="LOCAL" />
+      <updated>1604906727955</updated>
+    </task>
+    <option name="localTasksCounter" value="51" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -561,7 +561,6 @@
     <option name="oldMeFiltersMigrated" value="true" />
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="実装準備のためDatabaseの設定を行いました。" />
     <MESSAGE value="対応するURLと呼び出すコントローラーを設定するため、laravel_vue_quiz/routes/api.phpを編集しました。" />
     <MESSAGE value="ホーム画面のお知らせAPI連携を実装するため、InformationControllerを作成しました。" />
     <MESSAGE value="Informationテーブルのマイグレーションファイル作成し、作成したcreate_informations_tableを編集しました。" />
@@ -586,7 +585,8 @@
     <MESSAGE value="Answerモデル(laravel_vue_quiz/app/Answer.php)を作成し、編集しました。" />
     <MESSAGE value="Answerシーダー(laravel_vue_quiz/database/seeds/AnswerTableSeeder.php)を作成し、初期データの設定をするため編集しました。" />
     <MESSAGE value="Quiz画面からAPIを呼び出すため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。" />
-    <option name="LAST_COMMIT_MESSAGE" value="Quiz画面からAPIを呼び出すため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。" />
+    <MESSAGE value="API連携でデータを表示するため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。" />
+    <option name="LAST_COMMIT_MESSAGE" value="API連携でデータを表示するため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。" />
   </component>
   <component name="WindowStateProjectService">
     <state x="1064" y="380" key="#com.intellij.fileTypes.FileTypeChooser" timestamp="1603771211925">
@@ -617,10 +617,10 @@
       <screen x="0" y="23" width="1792" height="1097" />
     </state>
     <state x="747" y="209" key="SettingsEditor/0.23.1792.1097@0.23.1792.1097" timestamp="1604288623803" />
-    <state x="789" y="309" key="Vcs.Push.Dialog.v2" timestamp="1604906179465">
+    <state x="789" y="309" key="Vcs.Push.Dialog.v2" timestamp="1604906829955">
       <screen x="0" y="23" width="1792" height="1097" />
     </state>
-    <state x="789" y="309" key="Vcs.Push.Dialog.v2/0.23.1792.1097@0.23.1792.1097" timestamp="1604906179465" />
+    <state x="789" y="309" key="Vcs.Push.Dialog.v2/0.23.1792.1097@0.23.1792.1097" timestamp="1604906829955" />
     <state x="900" y="123" width="792" height="893" key="com.intellij.history.integration.ui.views.FileHistoryDialog" timestamp="1600932790272">
       <screen x="0" y="23" width="1792" height="1097" />
     </state>

--- a/resources/js/components/page/quiz.vue
+++ b/resources/js/components/page/quiz.vue
@@ -116,6 +116,29 @@ export default {
         });
     },
     methods: {
+        goAnswer(selectAnswerNum) {
+            if (selectAnswerNum === 0) {
+                // selectAnswerNumが0の場合は、click 「正解を表示する」ボタンのクリック alert-info、alert-dangerを非表示
+                this.isCorrect = false;
+                this.isMistake = false;
+            } else if (selectAnswerNum === Number(this.correctAnswerNo)) {
+                // 正解を押した場合 alert-infoを表示し、alert-dangerを非表示にする そしてスコアを加算する
+                this.isCorrect = true;
+                this.isMistake = false;
+                this.score += 1;
+            } else {
+                // 不正解の場合 alert-infoを非表示し、alert-dangerを表示にする
+                this.isMistake = true;
+                this.isCorrect = false;
+            }
+            // 回答済みの設定をONにする 同じ問題に２回以上の回答をさせないため、そして解説を表示するため
+            this.isAlreadyAnswered = true;
+
+            // 10問以上回答している場合は、クイズを終了
+            if (this.quizNumber >= 10) {
+                this.endQuiz();
+            }
+        },
         findNextQuiz(quizNumber) {
             this.title = this.quizData[quizNumber].title;
             this.answers = [
@@ -127,6 +150,25 @@ export default {
             this.commentary = this.quizData[quizNumber].answer.commentary;
             this.correctAnswerNo = this.quizData[quizNumber].answer.correct_answer_no;
             this.categoryName = this.quizData[quizNumber].category.name;
+        },
+        goNextQuiz() {
+            // 次の問題へをクリック
+            if (this.quizNumber >= 10) {
+                // 10問以上の場合はクイズを終了
+                this.endQuiz();
+            } else {
+                // 次のクイズを表示し、クイズ番号を加算、alert-info、alert-danger、解説を非表示にする
+                this.findNextQuiz(this.quizNumber);
+                this.quizNumber += 1;
+                this.isCorrect = false;
+                this.isMistake = false;
+                this.isAlreadyAnswered = false;
+            }
+        },
+        endQuiz() {
+            this.isQuizFinish = true;
+            this.answerNo = "-";
+            this.isAlreadyAnswered = true;
         },
     }
 };


### PR DESCRIPTION
## やったこと

Quiz画面のクイズ出題の2問目以降の問題を表示するため、laravel_vue_quiz/resources/js/components/page/Quiz.vueを編集しました。

## やらないこと

無し

## できるようになること（ユーザ目線）

・クイズ画面で二問目以降の問題を表示可能に。
・正解か不正解か未回答かによって、表示される画面が切り替わるように。
・10問以上回答している場合はクイズを強制終了。

## できなくなること（ユーザ目線）

無し

## 動作確認

■一問目
<img width="1035" alt="スクリーンショット 2020-11-09 16 24 21" src="https://user-images.githubusercontent.com/63224224/98516167-7d324600-22af-11eb-8b87-693f24f46be6.png">

■「次の問題へ」ボタンで二問目を表示
<img width="1012" alt="スクリーンショット 2020-11-09 17 13 59" src="https://user-images.githubusercontent.com/63224224/98516225-94713380-22af-11eb-82de-d162f9b72ff0.png">

■二問目の回答後
<img width="1037" alt="スクリーンショット 2020-11-09 17 14 12" src="https://user-images.githubusercontent.com/63224224/98516268-a2bf4f80-22af-11eb-8f49-5a8b5a3328bd.png">

■「次の問題へ」ボタンで三問目を表示し、回答後
<img width="1013" alt="スクリーンショット 2020-11-09 17 19 08" src="https://user-images.githubusercontent.com/63224224/98516419-d39f8480-22af-11eb-8d0f-24aca1171201.png">

■四問目で不正解の場合
<img width="1021" alt="スクリーンショット 2020-11-09 17 22 51" src="https://user-images.githubusercontent.com/63224224/98516780-46a8fb00-22b0-11eb-8025-b7a7fcbaa3a4.png">

■第六問目で未回答で解答を見た場合
<img width="984" alt="スクリーンショット 2020-11-09 17 24 11" src="https://user-images.githubusercontent.com/63224224/98516913-7bb54d80-22b0-11eb-8d66-73c0ddbb652d.png">

■十問目まで答えた画面
<img width="1018" alt="スクリーンショット 2020-11-09 17 26 14" src="https://user-images.githubusercontent.com/63224224/98517082-bb7c3500-22b0-11eb-85f8-2d6dab825ad0.png">


## その他

無し
